### PR TITLE
Add ProdIA-MAX to UIs and Studios

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ ACE-Step is a hybrid architecture combining a Language Model planner with a Diff
 | **Ace-Step-Wrangler** | Python + HTML/JS | DAW-inspired dark UI for musicians. Friendly sliders (Creativity, Strictly follow lyrics) instead of raw model params | [GitHub](https://github.com/tsondo/Ace-Step-Wrangler) |
 | ace-step-ui.pinokio | Pinokio | One-click launcher for ace-step-ui (v1.5), auto backend + frontend | [GitHub](https://github.com/cocktailpeanut/ace-step-ui.pinokio) |
 | **ACE-Step-1.5-for-windows** (sdbds) | Python + Windows | 936 Suno style tags with search/select; song parameter history; 4-language UI (EN/ZH/JA/KO); LoRA/LoKR training with GPU memory optimization | [GitHub](https://github.com/sdbds/ACE-Step-1.5-for-windows/tree/qinglong) |
+| **ProdIA-MAX** (ElWalki) | Node.js + Python | Fork of ace-step-ui with AI Chat Assistant (multi-LLM), Audio Codes conditioning, Voice Recorder + Whisper, Chord Progression Editor, Windows one-click setup | [GitHub](https://github.com/ElWalki/ProdIA_Max-Ace-Step-UI_Ace-Step-v1.5) |
 
 ## ComfyUI
 


### PR DESCRIPTION
## Add ProdIA-MAX to UIs and Studios

**ProdIA-MAX** is a Windows-focused fork of [ace-step-ui](https://github.com/fspecii/ace-step-ui) that adds:

- **AI Chat Assistant** — multi-provider LLM integration (OpenRouter, local Ollama, OpenAI) for lyrics writing and music production guidance
- **Audio Codes Pipeline** — extract and inject reference codes from existing songs for style conditioning
- **Voice Recorder + Whisper** — record vocals/melodies directly in the browser with automatic transcription
- **Chord Progression Editor** — visual chord builder that feeds progressions as reference audio
- **Windows One-Click Setup** — `setup.bat` installs Python venv, Node dependencies, and downloads models automatically

Built on top of fspecii's ace-step-ui (credited in README and throughout the codebase).

Repo: https://github.com/ElWalki/ProdIA_Max-Ace-Step-UI_Ace-Step-v1.5

### PR Checklist
- [x] The project is related to ACE-Step
- [x] The link is valid and points to a public resource
- [x] The description is accurate and concise
- [x] The entry is placed in the correct section (UIs and Studios)
- [x] No duplicate entries exist
- [x] The project is in active development