### PR TITLE
Add Majik's Music Studio to UIs and Studios

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ACE-Step is a hybrid architecture combining a Language Model planner with a Diff
 | **ACE-Step-1.5-for-windows** (sdbds) | Python + Windows | 936 Suno style tags with search/select; song parameter history; 4-language UI (EN/ZH/JA/KO); LoRA/LoKR training with GPU memory optimization | [GitHub](https://github.com/sdbds/ACE-Step-1.5-for-windows/tree/qinglong) |
 | **ProdIA-MAX** (ElWalki) | Node.js + Python | Fork of ace-step-ui with AI Chat Assistant (multi-LLM), Audio Codes conditioning, Voice Recorder + Whisper, Chord Progression Editor, Windows one-click setup | [GitHub](https://github.com/ElWalki/ProdIA_Max-Ace-Step-UI_Ace-Step-v1.5) |
 | **ACE-Step-RADIO** | Python | Continuous radio-style music stream powered by ACE-Step — auto-generates and plays songs back-to-back | [GitHub](https://github.com/PasiKoodaa/ACE-Step-RADIO) |
+| **Majik's Music Studio** | Swift/SwiftUI (macOS), GTK4 (Linux) | Free native desktop app (Apache 2.0). All 7 generation modes, full MLX acceleration on Apple Silicon, ACE Music Cloud integration, publishing to [majiks.online](https://majiks.online) (800+ tracks). Official ACE-Step partner. | [GitHub](https://github.com/Majiks-Studio/majiks-music-studio) |
 
 ## ComfyUI
 


### PR DESCRIPTION
Adds Majik's Music Studio to the UIs and Studios section.

**Majik's Music Studio** is a free, open-source native desktop app (Apache 2.0) for macOS and Linux.

- Swift/SwiftUI on macOS, GTK4 on Linux
- All 7 ACE-Step generation modes
- Full MLX acceleration on Apple Silicon
- ACE Music Cloud integration via built-in server pool
- Publishing to [majiks.online](https://majiks.online) — 800+ tracks generated with ACE-Step 1.5
- Official ACE-Step partner (coordinated with the ACE-Step team)

**Links:**
- Website: https://majiks.studio
- Platform: https://majiks.online
- GitHub: https://github.com/Majiks-Studio/majiks-music-studio